### PR TITLE
align naming of geometry attributes where possible

### DIFF
--- a/docs/mkdocs/feature_status/questions.md
+++ b/docs/mkdocs/feature_status/questions.md
@@ -78,3 +78,7 @@ Currently, we can have IlisMeta16:LineType.IlisMeta16:MaxOverlap in IlisMeta16 b
 unit is coming from.
 
 Not sure if this is relevant, because there is also no unit defined in e.g. GeometryCHLV95_V1
+
+## Encoding of directed polylines
+
+It's not clear from data nor reference manuals (2.3 and 2.4) how a directed polyline is encoded in XTF.

--- a/src/ili2py/writers/py/interlis23/templates/coord_types.jinja2
+++ b/src/ili2py/writers/py/interlis23/templates/coord_types.jinja2
@@ -5,10 +5,11 @@ class {{ coord_type.name }}Type:
     {%- if attribute.reference_system %}
     # {{ attribute.reference_system }}
     {%- endif %}
-    {{ attribute.name }}: "{{ attribute.types|join(' | ') }} | None" = field(
+    {{ attribute.name.lower() }}: "{{ attribute.types|join(' | ') }} | None" = field(
         default=None,
         metadata={
             "type": "Element",
+            "name": "{{ attribute.name }}",
             "namespace": "{{ render_config['namespace_map']['ili'] }}",
             "interlis": {
                 "meta_attributes": {

--- a/src/ili2py/writers/py/interlis23/templates/line_types.jinja2
+++ b/src/ili2py/writers/py/interlis23/templates/line_types.jinja2
@@ -38,10 +38,11 @@ class {{ line_type.name }}:
                 }
             }
         )
-    {{ line_type.attribute.name }}: Segment | None = field(
+    polyline: Segment | None = field(
         default=None,
         metadata={
             "type": "Element",
+            "name": "POLYLINE",
             "namespace": "{{ render_config['namespace_map']['ili'] }}",
             "interlis": {
                 "meta_attributes": {
@@ -99,16 +100,17 @@ class {{ line_type.name }}:
                         }
                     }
                 )
-            POLYLINE: Segment | None = field(
+            polyline: Segment | None = field(
                 default=None,
                 metadata={
                     "type": "Element",
+                    "name": "POLYLINE",
                     "namespace": "{{ render_config['namespace_map']['ili'] }}",
                     "interlis": {"meta_attributes": {}},
                 },
             )
 
-        BOUNDARY: list[{{ line_type.name }}POLYLINE] = field(
+        boundaries: list[{{ line_type.name }}POLYLINE] = field(
             default_factory=list,
             metadata={
                 "type": "Elements",
@@ -125,10 +127,11 @@ class {{ line_type.name }}:
             }
         )
 
-    SURFACE: {{ line_type.name }}BOUNDARY | None = field(
+    surface: {{ line_type.name }}BOUNDARY | None = field(
         default=None,
         metadata={
             "type": "Element",
+            "name": "SURFACE",
             "namespace": "{{ render_config['namespace_map']['ili'] }}",
             "interlis": {
                 "meta_attributes": {


### PR DESCRIPTION
This PR tries to align access to geometric attributes of built classes where possible. Especially for multi geometries there is a not easy gap between interlis 2.3 and 2.4 which need further investigation to be aligned.